### PR TITLE
fix: Correct policy ARN paths for Redshift and Athena to use service-role

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.72.1
+    rev: v1.72.2
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/main.tf
+++ b/main.tf
@@ -220,11 +220,11 @@ locals {
       attach = contains(var.data_sources, "SITEWISE")
     }
     redshift = {
-      arn    = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonGrafanaRedshiftAccess"
+      arn    = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonGrafanaRedshiftAccess"
       attach = contains(var.data_sources, "REDSHIFT")
     }
     athena = {
-      arn    = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonGrafanaAthenaAccess"
+      arn    = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonGrafanaAthenaAccess"
       attach = contains(var.data_sources, "ATHENA")
     }
     timestream = {


### PR DESCRIPTION
## Description
- Correct policy ARN paths for Redshift and Athena to use service-role

## Motivation and Context
- ARN paths are currently missing `/service-role/`
- Closes #5 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
