### PR TITLE
feat: Add support for using an existing/external workspace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.72.2
+    rev: v1.74.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ No modules.
 | <a name="input_authentication_providers"></a> [authentication\_providers](#input\_authentication\_providers) | The authentication providers for the workspace. Valid values are `AWS_SSO`, `SAML`, or both | `list(string)` | <pre>[<br>  "AWS_SSO"<br>]</pre> | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether a resources will be created | `bool` | `true` | no |
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Determines whether a an IAM role is created or to use an existing IAM role | `bool` | `true` | no |
+| <a name="input_create_workspace"></a> [create\_workspace](#input\_create\_workspace) | Determines whether a workspace will be created or to use an existing workspace | `bool` | `true` | no |
 | <a name="input_data_sources"></a> [data\_sources](#input\_data\_sources) | The data sources for the workspace. Valid values are `AMAZON_OPENSEARCH_SERVICE`, `ATHENA`, `CLOUDWATCH`, `PROMETHEUS`, `REDSHIFT`, `SITEWISE`, `TIMESTREAM`, `XRAY` | `list(string)` | `[]` | no |
 | <a name="input_description"></a> [description](#input\_description) | The workspace description | `string` | `null` | no |
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | Existing IAM role ARN for the workspace. Required if `create_iam_role` is set to `false` | `string` | `null` | no |
@@ -132,6 +133,7 @@ No modules.
 | <a name="input_stack_set_name"></a> [stack\_set\_name](#input\_stack\_set\_name) | The AWS CloudFormation stack set name that provisions IAM roles to be used by the workspace | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_use_iam_role_name_prefix"></a> [use\_iam\_role\_name\_prefix](#input\_use\_iam\_role\_name\_prefix) | Determines whether the IAM role name (`wokspace_iam_role_name`) is used as a prefix | `bool` | `true` | no |
+| <a name="input_workspace_id"></a> [workspace\_id](#input\_workspace\_id) | The ID of an existing workspace to use when `create_workspace` is `false` | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -18,22 +18,6 @@ locals {
 # Managed Grafana Module
 ################################################################################
 
-module "managed_grafana_disabled" {
-  source = "../.."
-
-  name   = local.name
-  create = false
-}
-
-module "managed_grafana_default" {
-  source = "../.."
-
-  name              = "${local.name}-default"
-  associate_license = false
-
-  tags = local.tags
-}
-
 module "managed_grafana" {
   source = "../.."
 
@@ -83,4 +67,20 @@ module "managed_grafana" {
   # }
 
   tags = local.tags
+}
+
+module "managed_grafana_default" {
+  source = "../.."
+
+  name              = "${local.name}-default"
+  associate_license = false
+
+  tags = local.tags
+}
+
+module "managed_grafana_disabled" {
+  source = "../.."
+
+  name   = local.name
+  create = false
 }

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,16 @@
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 
+locals {
+  workspace_id = var.create_workspace ? aws_grafana_workspace.this[0].id : var.workspace_id
+}
+
 ################################################################################
 # Workspace
 ################################################################################
 
 resource "aws_grafana_workspace" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.create_workspace ? 1 : 0
 
   name        = var.name
   description = var.description
@@ -253,7 +257,7 @@ resource "aws_grafana_workspace_saml_configuration" "this" {
   count = var.create && contains(var.authentication_providers, "SAML") ? 1 : 0
 
   editor_role_values = var.saml_editor_role_values
-  workspace_id       = aws_grafana_workspace.this[0].id
+  workspace_id       = local.workspace_id
 
   idp_metadata_url = var.saml_idp_metadata_url
   idp_metadata_xml = var.saml_idp_metadata_xml
@@ -277,7 +281,7 @@ resource "aws_grafana_license_association" "this" {
   count = var.create && var.associate_license ? 1 : 0
 
   license_type = var.license_type
-  workspace_id = aws_grafana_workspace.this[0].id
+  workspace_id = local.workspace_id
 }
 
 ################################################################################
@@ -290,5 +294,5 @@ resource "aws_grafana_role_association" "this" {
   role         = try(each.value.role, each.key)
   group_ids    = try(each.value.group_ids, null)
   user_ids     = try(each.value.user_ids, null)
-  workspace_id = aws_grafana_workspace.this[0].id
+  workspace_id = local.workspace_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,18 @@ variable "tags" {
 # Workspace
 ################################################################################
 
+variable "create_workspace" {
+  description = "Determines whether a workspace will be created or to use an existing workspace"
+  type        = bool
+  default     = true
+}
+
+variable "workspace_id" {
+  description = "The ID of an existing workspace to use when `create_workspace` is `false`"
+  type        = string
+  default     = ""
+}
+
 variable "name" {
   description = "The Grafana workspace name"
   type        = string


### PR DESCRIPTION
## Description
- Add support for using an existing/external workspace

## Motivation and Context
- Support scenarios where an existing/external workspace exists

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
