### PR TITLE
feat: Add workspace ID as output attribute

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0
+    rev: v1.77.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ No modules.
 | <a name="output_workspace_iam_role_arn"></a> [workspace\_iam\_role\_arn](#output\_workspace\_iam\_role\_arn) | IAM role ARN of the Grafana workspace |
 | <a name="output_workspace_iam_role_name"></a> [workspace\_iam\_role\_name](#output\_workspace\_iam\_role\_name) | IAM role name of the Grafana workspace |
 | <a name="output_workspace_iam_role_unique_id"></a> [workspace\_iam\_role\_unique\_id](#output\_workspace\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
-| <a name="output_workspace_id"></a> [workspace\_id](#output\_workspace\_id) | The ID of this Grafana workspace |
+| <a name="output_workspace_id"></a> [workspace\_id](#output\_workspace\_id) | The ID of the Grafana workspace |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ No modules.
 | <a name="output_workspace_iam_role_arn"></a> [workspace\_iam\_role\_arn](#output\_workspace\_iam\_role\_arn) | IAM role ARN of the Grafana workspace |
 | <a name="output_workspace_iam_role_name"></a> [workspace\_iam\_role\_name](#output\_workspace\_iam\_role\_name) | IAM role name of the Grafana workspace |
 | <a name="output_workspace_iam_role_unique_id"></a> [workspace\_iam\_role\_unique\_id](#output\_workspace\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
+| <a name="output_workspace_id"></a> [workspace\_id](#output\_workspace\_id) | The ID of this Grafana workspace |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -60,6 +60,7 @@ No inputs.
 | <a name="output_workspace_iam_role_arn"></a> [workspace\_iam\_role\_arn](#output\_workspace\_iam\_role\_arn) | IAM role ARN of the Grafana workspace |
 | <a name="output_workspace_iam_role_name"></a> [workspace\_iam\_role\_name](#output\_workspace\_iam\_role\_name) | IAM role name of the Grafana workspace |
 | <a name="output_workspace_iam_role_unique_id"></a> [workspace\_iam\_role\_unique\_id](#output\_workspace\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
+| <a name="output_workspace_id"></a> [workspace\_id](#output\_workspace\_id) | The ID of the Grafana workspace |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-managed-service-grafana/blob/main/LICENSE).

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -7,6 +7,11 @@ output "workspace_arn" {
   value       = module.managed_grafana.workspace_arn
 }
 
+output "workspace_id" {
+  description = "The ID of the Grafana workspace"
+  value       = module.managed_grafana.workspace_id
+}
+
 output "workspace_endpoint" {
   description = "The endpoint of the Grafana workspace"
   value       = module.managed_grafana.workspace_endpoint

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,6 +7,11 @@ output "workspace_arn" {
   value       = try(aws_grafana_workspace.this[0].arn, null)
 }
 
+output "workspace_id" {
+  description = "The ID of this Grafana workspace"
+  value       = try(aws_grafana_workspace.this[0].id, null)
+}
+
 output "workspace_endpoint" {
   description = "The endpoint of the Grafana workspace"
   value       = try(aws_grafana_workspace.this[0].endpoint, null)

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,7 +8,7 @@ output "workspace_arn" {
 }
 
 output "workspace_id" {
-  description = "The ID of this Grafana workspace"
+  description = "The ID of the Grafana workspace"
   value       = try(aws_grafana_workspace.this[0].id, null)
 }
 


### PR DESCRIPTION
## Description
Expose managed Grafana Workspace ID as a module output.

## Motivation and Context
In some circumstances, SAML configuration can only be setup after the workspace has been created (as the url of the workspace needs to be known in advance for the SAML app creation). Exposing Workspace ID allows this manipulation.

## Breaking Changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
