### PR TITLE
Adjust documentation to prevent errors while getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_access_type"></a> [account\_access\_type](#input\_account\_access\_type) | The type of account access for the workspace. Valid values are `CURRENT_ACCOUNT` and `ORGANIZATION` | `string` | `"CURRENT_ACCOUNT"` | no |
-| <a name="input_associate_license"></a> [associate\_license](#input\_associate\_license) | Determines whether a license will be associated with the workspace | `bool` | `true` | no |
+| <a name="input_associate_license"></a> [associate\_license](#input\_associate\_license) | Determines whether a license will be associated with the workspace. Use false if you do not have an active enterprise license in the AWS Marketplace. | `bool` | `true` | no |
 | <a name="input_authentication_providers"></a> [authentication\_providers](#input\_authentication\_providers) | The authentication providers for the workspace. Valid values are `AWS_SSO`, `SAML`, or both | `list(string)` | <pre>[<br>  "AWS_SSO"<br>]</pre> | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether a resources will be created | `bool` | `true` | no |
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Determines whether a an IAM role is created or to use an existing IAM role | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ No modules.
 | <a name="input_iam_role_policy_arns"></a> [iam\_role\_policy\_arns](#input\_iam\_role\_policy\_arns) | List of ARNs of IAM policies to attach to the workspace IAM role | `list(string)` | `[]` | no |
 | <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |
 | <a name="input_license_type"></a> [license\_type](#input\_license\_type) | The type of license for the workspace license association. Valid values are `ENTERPRISE` and `ENTERPRISE_FREE_TRIAL` | `string` | `"ENTERPRISE"` | no |
-| <a name="input_name"></a> [name](#input\_name) | The Grafana workspace name | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | The Grafana workspace name. Required if stack_set_name is not provided. Valid special characters include "-", ".", "_", “~”. Cannot contain non-ASCII characters or spaces. Max length of 255 characters. | `string` | `null` | no |
 | <a name="input_notification_destinations"></a> [notification\_destinations](#input\_notification\_destinations) | The notification destinations. If a data source is specified here, Amazon Managed Grafana will create IAM roles and permissions needed to use these destinations. Must be set to `SNS` | `list(string)` | `[]` | no |
 | <a name="input_organization_role_name"></a> [organization\_role\_name](#input\_organization\_role\_name) | The role name that the workspace uses to access resources through Amazon Organizations | `string` | `null` | no |
 | <a name="input_organizational_units"></a> [organizational\_units](#input\_organizational\_units) | The Amazon Organizations organizational units that the workspace is authorized to use data sources from | `list(string)` | `[]` | no |
@@ -150,7 +150,7 @@ No modules.
 | <a name="input_saml_name_assertion"></a> [saml\_name\_assertion](#input\_saml\_name\_assertion) | SAML authentication name assertion | `string` | `null` | no |
 | <a name="input_saml_org_assertion"></a> [saml\_org\_assertion](#input\_saml\_org\_assertion) | SAML authentication org assertion | `string` | `null` | no |
 | <a name="input_saml_role_assertion"></a> [saml\_role\_assertion](#input\_saml\_role\_assertion) | SAML authentication role assertion | `string` | `null` | no |
-| <a name="input_stack_set_name"></a> [stack\_set\_name](#input\_stack\_set\_name) | The AWS CloudFormation stack set name that provisions IAM roles to be used by the workspace | `string` | `null` | no |
+| <a name="input_stack_set_name"></a> [stack\_set\_name](#input\_stack\_set\_name) | The AWS CloudFormation stack set name that provisions IAM roles to be used by the workspace. Required if name is not provided. Valid special characters include "-", ".", "_", “~”. Cannot contain non-ASCII characters or spaces. Max length of 255 characters. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_use_iam_role_name_prefix"></a> [use\_iam\_role\_name\_prefix](#input\_use\_iam\_role\_name\_prefix) | Determines whether the IAM role name (`wokspace_iam_role_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_workspace_api_keys"></a> [workspace\_api\_keys](#input\_workspace\_api\_keys) | Map of workspace API key definitions to create | `any` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -249,7 +249,7 @@ variable "saml_role_assertion" {
 variable "associate_license" {
   description = "Determines whether a license will be associated with the workspace. Use false if you do not have an active enterprise license in the AWS Marketplace."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "license_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -247,7 +247,7 @@ variable "saml_role_assertion" {
 ################################################################################
 
 variable "associate_license" {
-  description = "Determines whether a license will be associated with the workspace"
+  description = "Determines whether a license will be associated with the workspace. Use false if you do not have an active enterprise license in the AWS Marketplace."
   type        = bool
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "workspace_id" {
 }
 
 variable "name" {
-  description = "The Grafana workspace name"
+  description = "The Grafana workspace name. Required if stack_set_name is not provided. Valid special characters include "-", ".", "_", “~”. Cannot contain non-ASCII characters or spaces. Max length of 255 characters."
   type        = string
   default     = null
 }
@@ -81,7 +81,7 @@ variable "organizational_units" {
 }
 
 variable "stack_set_name" {
-  description = "The AWS CloudFormation stack set name that provisions IAM roles to be used by the workspace"
+  description = "The AWS CloudFormation stack set name that provisions IAM roles to be used by the workspace. Required if name is not provided. Valid special characters include "-", ".", "_", “~”. Cannot contain non-ASCII characters or spaces. Max length of 255 characters."
   type        = string
   default     = null
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Following my issue request #13, I have made the suggested documentation changes and 1 code change for review by the repository maintainer. All documentation changes are additive only. The code change (var.associate_licese default = false) should be thoroughly thought-through since it will impact others using this registry if they exceed version 1.6.0, and possibly held for a later release. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change aims to reduce friction for first-time users of this registry module, especially where Terraform is able to process a build and AWS API responds poorly with limited details describing the problem. 
<!--- If it fixes an open issue, please link to the issue here. -->
Issue - #13 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
a18ca8fe13eceedeab0b1df5213c5627a8081f49 does impact users, though I'm not sure if it should be classified as a breaking change. I'll leave that to the maintainer's interpretation. 
The documentation changes do not break any compatibility.

<!-- If so, please provide an explanation why it is necessary. -->
I recommend that the variable associate_license be set to false as a default so that the system will build regardless of whether the user has a license attached to the account. The user can easily add a new attribute to the module call which enables the license association if they have one.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request


I have not done this, but I have provided example code in #13 that I tested exactly as posted. Minimal code is needed to reproduce this since it is a registry module. The only code change overwrites a variable default value, so nothing interacts with the module code directly. 
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
