### PR TITLE
feat: Add support for Grafana version specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.51 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.51 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
 
 ## Modules
 
@@ -128,6 +128,7 @@ No modules.
 | <a name="input_create_workspace"></a> [create\_workspace](#input\_create\_workspace) | Determines whether a workspace will be created or to use an existing workspace | `bool` | `true` | no |
 | <a name="input_data_sources"></a> [data\_sources](#input\_data\_sources) | The data sources for the workspace. Valid values are `AMAZON_OPENSEARCH_SERVICE`, `ATHENA`, `CLOUDWATCH`, `PROMETHEUS`, `REDSHIFT`, `SITEWISE`, `TIMESTREAM`, `XRAY` | `list(string)` | `[]` | no |
 | <a name="input_description"></a> [description](#input\_description) | The workspace description | `string` | `null` | no |
+| <a name="input_grafana_version"></a> [grafana\_version](#input\_grafana\_version) | Specifies the version of Grafana to support in the new workspace. If not specified, the default version for the `aws_grafana_workspace` resource will be used. See `aws_grafana_workspace` documentation for available options. | `string` | `null` | no |
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | Existing IAM role ARN for the workspace. Required if `create_iam_role` is set to `false` | `string` | `null` | no |
 | <a name="input_iam_role_description"></a> [iam\_role\_description](#input\_iam\_role\_description) | The description of the workspace IAM role | `string` | `null` | no |
 | <a name="input_iam_role_force_detach_policies"></a> [iam\_role\_force\_detach\_policies](#input\_iam\_role\_force\_detach\_policies) | Determines whether the workspace IAM role policies will be forced to detach | `bool` | `true` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -36,12 +36,14 @@ module "managed_grafana" {
   data_sources              = ["CLOUDWATCH", "PROMETHEUS", "XRAY"]
   notification_destinations = ["SNS"]
   stack_set_name            = local.name
+  grafana_version           = "9.4"
 
   configuration = jsonencode({
     unifiedAlerting = {
       enabled = true
     }
   })
+
 
   # vpc configuration
   vpc_configuration = {

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ resource "aws_grafana_workspace" "this" {
   authentication_providers = var.authentication_providers
   permission_type          = var.permission_type
 
+  grafana_version           = var.grafana_version
   configuration             = var.configuration
   data_sources              = var.data_sources
   notification_destinations = var.notification_destinations

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,12 @@ variable "permission_type" {
   default     = "SERVICE_MANAGED"
 }
 
+variable "grafana_version" {
+  description = "Specifies the version of Grafana to support in the new workspace. If not specified, the default version for the `aws_grafana_workspace` resource will be used. See `aws_grafana_workspace` documentation for available options."
+  type        = string
+  default     = null
+}
+
 variable "configuration" {
   description = "The configuration string for the workspace"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.51"
+      version = ">= 4.66.1"
     }
   }
 }


### PR DESCRIPTION
## Description

AWS Managed Grafana now supports 9.4, and the AWS terraform provider has been updated accordingly.
This PR adds the ability to inject a specific version. At the moment, the 4.66.1 provider allows either the default behavior, which uses 8.4, or the new version 9.4. The default now is 8.4, but I can imagine the provider eventually moving over to defaulting to 9.4 in the future.

## Motivation and Context

Grafana 9.4 resolves a number of issues that exist in 9.4, particularly around alerting. Having it as an option for users of this module is a nice to have and might unblock some from using this module.

## Breaking Changes

This PR bumps the minimum AWS provider version to 4.66.1.

The update path is also not possible without destroying and recreating the AWS Managed Grafana workspace.

AWS has published a migration tool for users who wish to migrate from 8.4 to 9.4, but this requires having a fresh 9.4 workspace online in addition to the source workspace.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as it's written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
