### PR TITLE
feat!: Add support for `network_access_control`, updated minimum supported version of Terraform to `1.0` and AWS provider to `5.0`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.81.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.67 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.67 |
 
 ## Modules
 
@@ -140,6 +140,7 @@ No modules.
 | <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |
 | <a name="input_license_type"></a> [license\_type](#input\_license\_type) | The type of license for the workspace license association. Valid values are `ENTERPRISE` and `ENTERPRISE_FREE_TRIAL` | `string` | `"ENTERPRISE"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The Grafana workspace name | `string` | `null` | no |
+| <a name="input_network_access_control"></a> [network\_access\_control](#input\_network\_access\_control) | Configuration for network access to your workspace | `any` | `{}` | no |
 | <a name="input_notification_destinations"></a> [notification\_destinations](#input\_notification\_destinations) | The notification destinations. If a data source is specified here, Amazon Managed Grafana will create IAM roles and permissions needed to use these destinations. Must be set to `SNS` | `list(string)` | `[]` | no |
 | <a name="input_organization_role_name"></a> [organization\_role\_name](#input\_organization\_role\_name) | The role name that the workspace uses to access resources through Amazon Organizations | `string` | `null` | no |
 | <a name="input_organizational_units"></a> [organizational\_units](#input\_organizational\_units) | The Amazon Organizations organizational units that the workspace is authorized to use data sources from | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.67 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.67 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,13 +24,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.67 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.67 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -23,7 +23,7 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.67 |
 
 ## Providers

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,13 +24,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.51 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.67 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.51 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.67 |
 
 ## Modules
 
@@ -39,7 +39,7 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_managed_grafana"></a> [managed\_grafana](#module\_managed\_grafana) | ../.. | n/a |
 | <a name="module_managed_grafana_default"></a> [managed\_grafana\_default](#module\_managed\_grafana\_default) | ../.. | n/a |
 | <a name="module_managed_grafana_disabled"></a> [managed\_grafana\_disabled](#module\_managed\_grafana\_disabled) | ../.. | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -44,7 +44,6 @@ module "managed_grafana" {
     }
   })
 
-
   # vpc configuration
   vpc_configuration = {
     subnet_ids = module.vpc.private_subnets
@@ -137,7 +136,7 @@ module "managed_grafana_disabled" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   name = local.name
   cidr = local.vpc_cidr
@@ -146,10 +145,8 @@ module "vpc" {
   private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]
   public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 48)]
 
-  enable_nat_gateway      = false # disabling for example, re-evaluate for your environment
-  single_nat_gateway      = true
-  enable_dns_hostnames    = true
-  map_public_ip_on_launch = false
+  enable_nat_gateway = false # disabling for example, re-evaluate for your environment
+  single_nat_gateway = true
 
   tags = local.tags
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.67"
+      version = ">= 5.0"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.51"
+      version = ">= 4.67"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,18 +26,6 @@ variable "workspace_id" {
   default     = ""
 }
 
-variable "name" {
-  description = "The Grafana workspace name"
-  type        = string
-  default     = null
-}
-
-variable "description" {
-  description = "The workspace description"
-  type        = string
-  default     = null
-}
-
 variable "account_access_type" {
   description = "The type of account access for the workspace. Valid values are `CURRENT_ACCOUNT` and `ORGANIZATION`"
   type        = string
@@ -50,18 +38,6 @@ variable "authentication_providers" {
   default     = ["AWS_SSO"]
 }
 
-variable "permission_type" {
-  description = "The permission type of the workspace. If `SERVICE_MANAGED` is specified, the IAM roles and IAM policy attachments are generated automatically. If `CUSTOMER_MANAGED` is specified, the IAM roles and IAM policy attachments will not be created"
-  type        = string
-  default     = "SERVICE_MANAGED"
-}
-
-variable "grafana_version" {
-  description = "Specifies the version of Grafana to support in the new workspace. If not specified, the default version for the `aws_grafana_workspace` resource will be used. See `aws_grafana_workspace` documentation for available options."
-  type        = string
-  default     = null
-}
-
 variable "configuration" {
   description = "The configuration string for the workspace"
   type        = string
@@ -72,6 +48,30 @@ variable "data_sources" {
   description = "The data sources for the workspace. Valid values are `AMAZON_OPENSEARCH_SERVICE`, `ATHENA`, `CLOUDWATCH`, `PROMETHEUS`, `REDSHIFT`, `SITEWISE`, `TIMESTREAM`, `XRAY`"
   type        = list(string)
   default     = []
+}
+
+variable "description" {
+  description = "The workspace description"
+  type        = string
+  default     = null
+}
+
+variable "grafana_version" {
+  description = "Specifies the version of Grafana to support in the new workspace. If not specified, the default version for the `aws_grafana_workspace` resource will be used. See `aws_grafana_workspace` documentation for available options."
+  type        = string
+  default     = null
+}
+
+variable "name" {
+  description = "The Grafana workspace name"
+  type        = string
+  default     = null
+}
+
+variable "network_access_control" {
+  description = "Configuration for network access to your workspace"
+  type        = any
+  default     = {}
 }
 
 variable "notification_destinations" {
@@ -92,6 +92,12 @@ variable "organizational_units" {
   default     = []
 }
 
+variable "permission_type" {
+  description = "The permission type of the workspace. If `SERVICE_MANAGED` is specified, the IAM roles and IAM policy attachments are generated automatically. If `CUSTOMER_MANAGED` is specified, the IAM roles and IAM policy attachments will not be created"
+  type        = string
+  default     = "SERVICE_MANAGED"
+}
+
 variable "stack_set_name" {
   description = "The AWS CloudFormation stack set name that provisions IAM roles to be used by the workspace"
   type        = string
@@ -100,16 +106,6 @@ variable "stack_set_name" {
 
 variable "vpc_configuration" {
   description = "The configuration settings for an Amazon VPC that contains data sources for your Grafana workspace to connect to"
-  type        = any
-  default     = {}
-}
-
-################################################################################
-# Workspace API Key
-################################################################################
-
-variable "workspace_api_keys" {
-  description = "Map of workspace API key definitions to create"
   type        = any
   default     = {}
 }
@@ -185,6 +181,16 @@ variable "iam_role_tags" {
 }
 
 ################################################################################
+# Workspace API Key
+################################################################################
+
+variable "workspace_api_keys" {
+  description = "Map of workspace API key definitions to create"
+  type        = any
+  default     = {}
+}
+
+################################################################################
 # Workspace SAML Configuration
 ################################################################################
 
@@ -192,24 +198,6 @@ variable "create_saml_configuration" {
   description = "Determines whether the SAML configuration will be created"
   type        = bool
   default     = true
-}
-
-variable "saml_editor_role_values" {
-  description = "SAML authentication editor role values"
-  type        = list(string)
-  default     = []
-}
-
-variable "saml_idp_metadata_url" {
-  description = "SAML authentication IDP Metadata URL. Note that either `saml_idp_metadata_url` or `saml_idp_metadata_xml`"
-  type        = string
-  default     = null
-}
-
-variable "saml_idp_metadata_xml" {
-  description = "SAML authentication IDP Metadata XML. Note that either `saml_idp_metadata_url` or `saml_idp_metadata_xml`"
-  type        = string
-  default     = null
 }
 
 variable "saml_admin_role_values" {
@@ -224,6 +212,12 @@ variable "saml_allowed_organizations" {
   default     = []
 }
 
+variable "saml_editor_role_values" {
+  description = "SAML authentication editor role values"
+  type        = list(string)
+  default     = []
+}
+
 variable "saml_email_assertion" {
   description = "SAML authentication email assertion"
   type        = string
@@ -232,6 +226,18 @@ variable "saml_email_assertion" {
 
 variable "saml_groups_assertion" {
   description = "SAML authentication groups assertion"
+  type        = string
+  default     = null
+}
+
+variable "saml_idp_metadata_url" {
+  description = "SAML authentication IDP Metadata URL. Note that either `saml_idp_metadata_url` or `saml_idp_metadata_xml`"
+  type        = string
+  default     = null
+}
+
+variable "saml_idp_metadata_xml" {
+  description = "SAML authentication IDP Metadata XML. Note that either `saml_idp_metadata_url` or `saml_idp_metadata_xml`"
   type        = string
   default     = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.67"
+      version = ">= 5.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 4.67"
     }
   }
 }


### PR DESCRIPTION
## Description
- Add support for `network_access_control`
- Order arguments to align with provider to make comparison easier (sorry for the whitespace noise!)
- Update minimum supported version of Terraform to 1.0
- Update minimum supported version of AWS provider to 5.0

## Motivation and Context
- Resolves #22
- Resolves #23

## Breaking Changes
- Yes; Terraform and provider MSV have changed

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
