### PR TITLE
feat: Add support for external integration with prometheus alertmanager for grafana

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.81.0
+    rev: v1.83.4
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ No modules.
 | <a name="output_workspace_iam_role_arn"></a> [workspace\_iam\_role\_arn](#output\_workspace\_iam\_role\_arn) | IAM role ARN of the Grafana workspace |
 | <a name="output_workspace_iam_role_name"></a> [workspace\_iam\_role\_name](#output\_workspace\_iam\_role\_name) | IAM role name of the Grafana workspace |
 | <a name="output_workspace_iam_role_unique_id"></a> [workspace\_iam\_role\_unique\_id](#output\_workspace\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
+| <a name="output_workspace_iam_policy_arn"></a> [workspace\_iam\_policy\_arn](#output\_workspace\_iam\_policy\_arn) | IAM Policy ARN of the Grafana workspace |
+| <a name="output_workspace_iam_policy_name"></a> [workspace\_iam\_policy\_name](#output\_workspace\_iam\_policy\_name) | IAM Policy name of the Grafana workspace |
+| <a name="output_workspace_iam_policy_id"></a> [workspace\_iam\_policy\_id](#output\_workspace\_iam\_policy\_id) | Stable and unique string identifying the IAM Policy |
 | <a name="output_workspace_id"></a> [workspace\_id](#output\_workspace\_id) | The ID of the Grafana workspace |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/README.md
+++ b/README.md
@@ -183,12 +183,12 @@ No modules.
 | <a name="output_workspace_arn"></a> [workspace\_arn](#output\_workspace\_arn) | The Amazon Resource Name (ARN) of the Grafana workspace |
 | <a name="output_workspace_endpoint"></a> [workspace\_endpoint](#output\_workspace\_endpoint) | The endpoint of the Grafana workspace |
 | <a name="output_workspace_grafana_version"></a> [workspace\_grafana\_version](#output\_workspace\_grafana\_version) | The version of Grafana running on the workspace |
-| <a name="output_workspace_iam_role_arn"></a> [workspace\_iam\_role\_arn](#output\_workspace\_iam\_role\_arn) | IAM role ARN of the Grafana workspace |
-| <a name="output_workspace_iam_role_name"></a> [workspace\_iam\_role\_name](#output\_workspace\_iam\_role\_name) | IAM role name of the Grafana workspace |
-| <a name="output_workspace_iam_role_unique_id"></a> [workspace\_iam\_role\_unique\_id](#output\_workspace\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
 | <a name="output_workspace_iam_policy_arn"></a> [workspace\_iam\_policy\_arn](#output\_workspace\_iam\_policy\_arn) | IAM Policy ARN of the Grafana workspace |
 | <a name="output_workspace_iam_policy_name"></a> [workspace\_iam\_policy\_name](#output\_workspace\_iam\_policy\_name) | IAM Policy name of the Grafana workspace |
-| <a name="output_workspace_iam_policy_id"></a> [workspace\_iam\_policy\_id](#output\_workspace\_iam\_policy\_id) | Stable and unique string identifying the IAM Policy |
+| <a name="output_workspace_iam_role_arn"></a> [workspace\_iam\_role\_arn](#output\_workspace\_iam\_role\_arn) | IAM role ARN of the Grafana workspace |
+| <a name="output_workspace_iam_role_name"></a> [workspace\_iam\_role\_name](#output\_workspace\_iam\_role\_name) | IAM role name of the Grafana workspace |
+| <a name="output_workspace_iam_role_policy_id"></a> [workspace\_iam\_role\_policy\_id](#output\_workspace\_iam\_role\_policy\_id) | Stable and unique string identifying the IAM Policy |
+| <a name="output_workspace_iam_role_unique_id"></a> [workspace\_iam\_role\_unique\_id](#output\_workspace\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
 | <a name="output_workspace_id"></a> [workspace\_id](#output\_workspace\_id) | The ID of the Grafana workspace |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ No modules.
 | <a name="input_create_workspace"></a> [create\_workspace](#input\_create\_workspace) | Determines whether a workspace will be created or to use an existing workspace | `bool` | `true` | no |
 | <a name="input_data_sources"></a> [data\_sources](#input\_data\_sources) | The data sources for the workspace. Valid values are `AMAZON_OPENSEARCH_SERVICE`, `ATHENA`, `CLOUDWATCH`, `PROMETHEUS`, `REDSHIFT`, `SITEWISE`, `TIMESTREAM`, `XRAY` | `list(string)` | `[]` | no |
 | <a name="input_description"></a> [description](#input\_description) | The workspace description | `string` | `null` | no |
+| <a name="input_enable_alerts"></a> [enable\_alerts](#input\_enable\_alerts) | Determines whether IAM permissions for alerting are enabled for the workspace IAM role | `bool` | `false` | no |
 | <a name="input_grafana_version"></a> [grafana\_version](#input\_grafana\_version) | Specifies the version of Grafana to support in the new workspace. If not specified, the default version for the `aws_grafana_workspace` resource will be used. See `aws_grafana_workspace` documentation for available options. | `string` | `null` | no |
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | Existing IAM role ARN for the workspace. Required if `create_iam_role` is set to `false` | `string` | `null` | no |
 | <a name="input_iam_role_description"></a> [iam\_role\_description](#input\_iam\_role\_description) | The description of the workspace IAM role | `string` | `null` | no |
@@ -183,11 +184,11 @@ No modules.
 | <a name="output_workspace_arn"></a> [workspace\_arn](#output\_workspace\_arn) | The Amazon Resource Name (ARN) of the Grafana workspace |
 | <a name="output_workspace_endpoint"></a> [workspace\_endpoint](#output\_workspace\_endpoint) | The endpoint of the Grafana workspace |
 | <a name="output_workspace_grafana_version"></a> [workspace\_grafana\_version](#output\_workspace\_grafana\_version) | The version of Grafana running on the workspace |
-| <a name="output_workspace_iam_policy_arn"></a> [workspace\_iam\_policy\_arn](#output\_workspace\_iam\_policy\_arn) | IAM Policy ARN of the Grafana workspace |
-| <a name="output_workspace_iam_policy_name"></a> [workspace\_iam\_policy\_name](#output\_workspace\_iam\_policy\_name) | IAM Policy name of the Grafana workspace |
 | <a name="output_workspace_iam_role_arn"></a> [workspace\_iam\_role\_arn](#output\_workspace\_iam\_role\_arn) | IAM role ARN of the Grafana workspace |
 | <a name="output_workspace_iam_role_name"></a> [workspace\_iam\_role\_name](#output\_workspace\_iam\_role\_name) | IAM role name of the Grafana workspace |
+| <a name="output_workspace_iam_role_policy_arn"></a> [workspace\_iam\_role\_policy\_arn](#output\_workspace\_iam\_role\_policy\_arn) | IAM Policy ARN of the Grafana workspace IAM role |
 | <a name="output_workspace_iam_role_policy_id"></a> [workspace\_iam\_role\_policy\_id](#output\_workspace\_iam\_role\_policy\_id) | Stable and unique string identifying the IAM Policy |
+| <a name="output_workspace_iam_role_policy_name"></a> [workspace\_iam\_role\_policy\_name](#output\_workspace\_iam\_role\_policy\_name) | IAM Policy name of the Grafana workspace IAM role |
 | <a name="output_workspace_iam_role_unique_id"></a> [workspace\_iam\_role\_unique\_id](#output\_workspace\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
 | <a name="output_workspace_id"></a> [workspace\_id](#output\_workspace\_id) | The ID of the Grafana workspace |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -64,6 +64,9 @@ No inputs.
 | <a name="output_workspace_grafana_version"></a> [workspace\_grafana\_version](#output\_workspace\_grafana\_version) | The version of Grafana running on the workspace |
 | <a name="output_workspace_iam_role_arn"></a> [workspace\_iam\_role\_arn](#output\_workspace\_iam\_role\_arn) | IAM role ARN of the Grafana workspace |
 | <a name="output_workspace_iam_role_name"></a> [workspace\_iam\_role\_name](#output\_workspace\_iam\_role\_name) | IAM role name of the Grafana workspace |
+| <a name="output_workspace_iam_role_policy_arn"></a> [workspace\_iam\_role\_policy\_arn](#output\_workspace\_iam\_role\_policy\_arn) | IAM Policy ARN of the Grafana workspace IAM role |
+| <a name="output_workspace_iam_role_policy_id"></a> [workspace\_iam\_role\_policy\_id](#output\_workspace\_iam\_role\_policy\_id) | Stable and unique string identifying the IAM Policy |
+| <a name="output_workspace_iam_role_policy_name"></a> [workspace\_iam\_role\_policy\_name](#output\_workspace\_iam\_role\_policy\_name) | IAM Policy name of the Grafana workspace IAM role |
 | <a name="output_workspace_iam_role_unique_id"></a> [workspace\_iam\_role\_unique\_id](#output\_workspace\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
 | <a name="output_workspace_id"></a> [workspace\_id](#output\_workspace\_id) | The ID of the Grafana workspace |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -51,6 +51,25 @@ output "workspace_iam_role_unique_id" {
 }
 
 ################################################################################
+# Workspace IAM Policy
+################################################################################
+
+output "workspace_iam_role_policy_arn" {
+  description = "IAM Policy ARN of the Grafana workspace IAM role"
+  value       = module.managed_grafana.workspace_iam_role_policy_arn
+}
+
+output "workspace_iam_role_policy_name" {
+  description = "IAM Policy name of the Grafana workspace IAM role"
+  value       = module.managed_grafana.workspace_iam_role_policy_name
+}
+
+output "workspace_iam_role_policy_id" {
+  description = "Stable and unique string identifying the IAM Policy"
+  value       = module.managed_grafana.workspace_iam_role_policy_id
+}
+
+################################################################################
 # Workspace SAML Configuration
 ################################################################################
 

--- a/main.tf
+++ b/main.tf
@@ -265,6 +265,13 @@ data "aws_iam_policy_document" "this" {
         "aps:GetLabels",
         "aps:GetSeries",
         "aps:GetMetricMetadata",
+        "aps:ListRules",
+        "aps:ListAlertManagerSilences",
+        "aps:ListAlertManagerAlerts",
+        "aps:GetAlertManagerStatus",
+        "aps:ListAlertManagerAlertGroups",
+        "aps:PutAlertManagerSilences",
+        "aps:DeleteAlertManagerSilences"
       ]
       resources = ["*"]
     }

--- a/main.tf
+++ b/main.tf
@@ -265,6 +265,18 @@ data "aws_iam_policy_document" "this" {
         "aps:GetLabels",
         "aps:GetSeries",
         "aps:GetMetricMetadata",
+      ]
+      resources = ["*"]
+    }
+  }
+
+  # Prometheus alerts
+  # https://docs.aws.amazon.com/prometheus/latest/userguide/integrating-grafana.html
+  dynamic "statement" {
+    for_each = contains(var.data_sources, "PROMETHEUS") && var.enable_alerts ? [1] : []
+
+    content {
+      actions = [
         "aps:ListRules",
         "aps:ListAlertManagerSilences",
         "aps:ListAlertManagerAlerts",

--- a/outputs.tf
+++ b/outputs.tf
@@ -51,6 +51,24 @@ output "workspace_iam_role_unique_id" {
 }
 
 ################################################################################
+# Workspace IAM Policy
+################################################################################
+
+output "workspace_iam_policy_arn" {
+  description = "IAM Policy ARN of the Grafana workspace"
+  value       = try(aws_iam_policy.this[0].arn, null)
+}
+output "workspace_iam_policy_name" {
+  description = "IAM Policy name of the Grafana workspace"
+  value       = try(aws_iam_policy.this[0].name, null)
+}
+
+output "workspace_iam_role_policy_id" {
+  description = "Stable and unique string identifying the IAM Policy"
+  value       = try(aws_iam_policy.this[0].policy_id, null)
+}
+
+################################################################################
 # Workspace SAML Configuration
 ################################################################################
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -54,12 +54,13 @@ output "workspace_iam_role_unique_id" {
 # Workspace IAM Policy
 ################################################################################
 
-output "workspace_iam_policy_arn" {
-  description = "IAM Policy ARN of the Grafana workspace"
+output "workspace_iam_role_policy_arn" {
+  description = "IAM Policy ARN of the Grafana workspace IAM role"
   value       = try(aws_iam_policy.this[0].arn, null)
 }
-output "workspace_iam_policy_name" {
-  description = "IAM Policy name of the Grafana workspace"
+
+output "workspace_iam_role_policy_name" {
+  description = "IAM Policy name of the Grafana workspace IAM role"
   value       = try(aws_iam_policy.this[0].name, null)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -180,6 +180,12 @@ variable "iam_role_tags" {
   default     = {}
 }
 
+variable "enable_alerts" {
+  description = "Determines whether IAM permissions for alerting are enabled for the workspace IAM role"
+  type        = bool
+  default     = false
+}
+
 ################################################################################
 # Workspace API Key
 ################################################################################


### PR DESCRIPTION
…ation with prometheus alertmanager for grafana. Added outputs for IAM policy.

## Description
1. Updated Prometheus policy document to add support for external integration with prometheus alertmanager for grafana. per https://docs.aws.amazon.com/prometheus/latest/userguide/integrating-grafana.html
2. Added outputs for IAM policy created.
3. Updated readme to include outputs for IAM policy.

## Motivation and Context


Amazon Managed Grafana must have the following permissions for your Prometheus resources. You must add them to either the service-managed or customer-managed policies described in https://docs.aws.amazon.com/grafana/latest/userguide/AMG-manage-permissions.html.
    aps:ListRules
    aps:ListAlertManagerSilences
    aps:ListAlertManagerAlerts
    aps:GetAlertManagerStatus
    aps:ListAlertManagerAlertGroups
    aps:PutAlertManagerSilences
    aps:DeleteAlertManagerSilences

## Breaking Changes
No

## How Has This Been Tested?
- [ *] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ *] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ *] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
