### PR TITLE
fix: IAM policy to correct permission for deleting alert manager silence

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -283,7 +283,7 @@ data "aws_iam_policy_document" "this" {
         "aps:GetAlertManagerStatus",
         "aps:ListAlertManagerAlertGroups",
         "aps:PutAlertManagerSilences",
-        "aps:DeleteAlertManagerSilences"
+        "aps:DeleteAlertManagerSilence"
       ]
       resources = ["*"]
     }


### PR DESCRIPTION
This PR updates the IAM policy document to correct the permission associated with the deletion of alert silences in Amazon Managed Service for Prometheus (APS).

https://docs.aws.amazon.com/prometheus/latest/userguide/integrating-grafana.html