### PR TITLE
feat: Add support for service account and service account token resources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.92.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -24,7 +24,7 @@ repos:
           - '--args=--only=terraform_unused_required_providers'
       - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ No modules.
 | [aws_grafana_workspace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_workspace) | resource |
 | [aws_grafana_workspace_api_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_workspace_api_key) | resource |
 | [aws_grafana_workspace_saml_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_workspace_saml_configuration) | resource |
+| [aws_grafana_workspace_service_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_workspace_service_account) | resource |
+| [aws_grafana_workspace_service_account_token.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_workspace_service_account_token) | resource |
 | [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -123,8 +125,10 @@ No modules.
 | <a name="input_configuration"></a> [configuration](#input\_configuration) | The configuration string for the workspace | `string` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether a resources will be created | `bool` | `true` | no |
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Determines whether a an IAM role is created or to use an existing IAM role | `bool` | `true` | no |
+| <a name="input_create_sa_tokens"></a> [create\_sa\_tokens](#input\_create\_sa\_tokens) | Determines whether a service account token will be created | `bool` | `true` | no |
 | <a name="input_create_saml_configuration"></a> [create\_saml\_configuration](#input\_create\_saml\_configuration) | Determines whether the SAML configuration will be created | `bool` | `true` | no |
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Determines if a security group is created | `bool` | `true` | no |
+| <a name="input_create_service_account"></a> [create\_service\_account](#input\_create\_service\_account) | Determines whether a service account will be created | `bool` | `true` | no |
 | <a name="input_create_workspace"></a> [create\_workspace](#input\_create\_workspace) | Determines whether a workspace will be created or to use an existing workspace | `bool` | `true` | no |
 | <a name="input_data_sources"></a> [data\_sources](#input\_data\_sources) | The data sources for the workspace. Valid values are `AMAZON_OPENSEARCH_SERVICE`, `ATHENA`, `CLOUDWATCH`, `PROMETHEUS`, `REDSHIFT`, `SITEWISE`, `TIMESTREAM`, `XRAY` | `list(string)` | `[]` | no |
 | <a name="input_description"></a> [description](#input\_description) | The workspace description | `string` | `null` | no |
@@ -170,6 +174,8 @@ No modules.
 | <a name="input_vpc_configuration"></a> [vpc\_configuration](#input\_vpc\_configuration) | The configuration settings for an Amazon VPC that contains data sources for your Grafana workspace to connect to | `any` | `{}` | no |
 | <a name="input_workspace_api_keys"></a> [workspace\_api\_keys](#input\_workspace\_api\_keys) | Map of workspace API key definitions to create | `any` | `{}` | no |
 | <a name="input_workspace_id"></a> [workspace\_id](#input\_workspace\_id) | The ID of an existing workspace to use when `create_workspace` is `false` | `string` | `""` | no |
+| <a name="input_workspace_sa_tokens"></a> [workspace\_sa\_tokens](#input\_workspace\_sa\_tokens) | Map of workspace service account tokens to create | `any` | `{}` | no |
+| <a name="input_workspace_service_accounts"></a> [workspace\_service\_accounts](#input\_workspace\_service\_accounts) | Map of workspace service account definitions to create | `any` | `{}` | no |
 
 ## Outputs
 
@@ -191,6 +197,7 @@ No modules.
 | <a name="output_workspace_iam_role_policy_name"></a> [workspace\_iam\_role\_policy\_name](#output\_workspace\_iam\_role\_policy\_name) | IAM Policy name of the Grafana workspace IAM role |
 | <a name="output_workspace_iam_role_unique_id"></a> [workspace\_iam\_role\_unique\_id](#output\_workspace\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
 | <a name="output_workspace_id"></a> [workspace\_id](#output\_workspace\_id) | The ID of the Grafana workspace |
+| <a name="output_workspace_sa_tokens"></a> [workspace\_sa\_tokens](#output\_workspace\_sa\_tokens) | The workspace API keys created including their attributes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.59 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.59 |
 
 ## Modules
 
@@ -125,10 +125,8 @@ No modules.
 | <a name="input_configuration"></a> [configuration](#input\_configuration) | The configuration string for the workspace | `string` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether a resources will be created | `bool` | `true` | no |
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Determines whether a an IAM role is created or to use an existing IAM role | `bool` | `true` | no |
-| <a name="input_create_sa_tokens"></a> [create\_sa\_tokens](#input\_create\_sa\_tokens) | Determines whether a service account token will be created | `bool` | `true` | no |
 | <a name="input_create_saml_configuration"></a> [create\_saml\_configuration](#input\_create\_saml\_configuration) | Determines whether the SAML configuration will be created | `bool` | `true` | no |
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Determines if a security group is created | `bool` | `true` | no |
-| <a name="input_create_service_account"></a> [create\_service\_account](#input\_create\_service\_account) | Determines whether a service account will be created | `bool` | `true` | no |
 | <a name="input_create_workspace"></a> [create\_workspace](#input\_create\_workspace) | Determines whether a workspace will be created or to use an existing workspace | `bool` | `true` | no |
 | <a name="input_data_sources"></a> [data\_sources](#input\_data\_sources) | The data sources for the workspace. Valid values are `AMAZON_OPENSEARCH_SERVICE`, `ATHENA`, `CLOUDWATCH`, `PROMETHEUS`, `REDSHIFT`, `SITEWISE`, `TIMESTREAM`, `XRAY` | `list(string)` | `[]` | no |
 | <a name="input_description"></a> [description](#input\_description) | The workspace description | `string` | `null` | no |
@@ -174,7 +172,7 @@ No modules.
 | <a name="input_vpc_configuration"></a> [vpc\_configuration](#input\_vpc\_configuration) | The configuration settings for an Amazon VPC that contains data sources for your Grafana workspace to connect to | `any` | `{}` | no |
 | <a name="input_workspace_api_keys"></a> [workspace\_api\_keys](#input\_workspace\_api\_keys) | Map of workspace API key definitions to create | `any` | `{}` | no |
 | <a name="input_workspace_id"></a> [workspace\_id](#input\_workspace\_id) | The ID of an existing workspace to use when `create_workspace` is `false` | `string` | `""` | no |
-| <a name="input_workspace_sa_tokens"></a> [workspace\_sa\_tokens](#input\_workspace\_sa\_tokens) | Map of workspace service account tokens to create | `any` | `{}` | no |
+| <a name="input_workspace_service_account_tokens"></a> [workspace\_service\_account\_tokens](#input\_workspace\_service\_account\_tokens) | Map of workspace service account tokens to create | `any` | `{}` | no |
 | <a name="input_workspace_service_accounts"></a> [workspace\_service\_accounts](#input\_workspace\_service\_accounts) | Map of workspace service account definitions to create | `any` | `{}` | no |
 
 ## Outputs
@@ -197,7 +195,8 @@ No modules.
 | <a name="output_workspace_iam_role_policy_name"></a> [workspace\_iam\_role\_policy\_name](#output\_workspace\_iam\_role\_policy\_name) | IAM Policy name of the Grafana workspace IAM role |
 | <a name="output_workspace_iam_role_unique_id"></a> [workspace\_iam\_role\_unique\_id](#output\_workspace\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
 | <a name="output_workspace_id"></a> [workspace\_id](#output\_workspace\_id) | The ID of the Grafana workspace |
-| <a name="output_workspace_sa_tokens"></a> [workspace\_sa\_tokens](#output\_workspace\_sa\_tokens) | The workspace API keys created including their attributes |
+| <a name="output_workspace_service_account_tokens"></a> [workspace\_service\_account\_tokens](#output\_workspace\_service\_account\_tokens) | The workspace service account tokens created including their attributes |
+| <a name="output_workspace_service_accounts"></a> [workspace\_service\_accounts](#output\_workspace\_service\_accounts) | The workspace service accounts created including their attributes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -69,6 +69,7 @@ No inputs.
 | <a name="output_workspace_iam_role_policy_name"></a> [workspace\_iam\_role\_policy\_name](#output\_workspace\_iam\_role\_policy\_name) | IAM Policy name of the Grafana workspace IAM role |
 | <a name="output_workspace_iam_role_unique_id"></a> [workspace\_iam\_role\_unique\_id](#output\_workspace\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
 | <a name="output_workspace_id"></a> [workspace\_id](#output\_workspace\_id) | The ID of the Grafana workspace |
+| <a name="output_workspace_sa_tokens"></a> [workspace\_sa\_tokens](#output\_workspace\_sa\_tokens) | The workspace API keys created including their attributes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-managed-service-grafana/blob/main/LICENSE).

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,13 +24,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.59 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.59 |
 
 ## Modules
 
@@ -69,7 +69,8 @@ No inputs.
 | <a name="output_workspace_iam_role_policy_name"></a> [workspace\_iam\_role\_policy\_name](#output\_workspace\_iam\_role\_policy\_name) | IAM Policy name of the Grafana workspace IAM role |
 | <a name="output_workspace_iam_role_unique_id"></a> [workspace\_iam\_role\_unique\_id](#output\_workspace\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
 | <a name="output_workspace_id"></a> [workspace\_id](#output\_workspace\_id) | The ID of the Grafana workspace |
-| <a name="output_workspace_sa_tokens"></a> [workspace\_sa\_tokens](#output\_workspace\_sa\_tokens) | The workspace API keys created including their attributes |
+| <a name="output_workspace_service_account_tokens"></a> [workspace\_service\_account\_tokens](#output\_workspace\_service\_account\_tokens) | The workspace service account tokens created including their attributes |
+| <a name="output_workspace_service_accounts"></a> [workspace\_service\_accounts](#output\_workspace\_service\_accounts) | The workspace service accounts created including their attributes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-managed-service-grafana/blob/main/LICENSE).

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 data "aws_availability_zones" "available" {}
 
 locals {
-  region      = "us-west-2"
+  region      = "us-east-1"
   name        = "amg-ex-${replace(basename(path.cwd), "_", "-")}"
   description = "AWS Managed Grafana service for ${local.name}"
 
@@ -83,34 +83,30 @@ module "managed_grafana" {
   # Workspace service accounts
   workspace_service_accounts = {
     viewer = {
-      sa_name      = "viewer"
       grafana_role = "VIEWER"
     }
     editor = {
-      sa_name      = "editor"
+      name         = "editor-example"
       grafana_role = "EDITOR"
     }
     admin = {
-      sa_name      = "admin"
       grafana_role = "ADMIN"
     }
   }
 
-  workspace_sa_tokens = {
+  workspace_service_account_tokens = {
     viewer = {
-      token_name      = "viewer-example"
-      sa_account      = "viewer"
-      seconds_to_live = 3600
+      service_account_key = "viewer"
+      seconds_to_live     = 3600
     }
     editor = {
-      token_name      = "editor-example"
-      sa_account      = "editor"
-      seconds_to_live = 3600
+      name                = "editor-example"
+      service_account_key = "editor"
+      seconds_to_live     = 3600
     }
     admin = {
-      token_name      = "admin-example"
-      sa_account      = "admin"
-      seconds_to_live = 3600
+      service_account_key = "admin"
+      seconds_to_live     = 3600
     }
   }
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -36,7 +36,7 @@ module "managed_grafana" {
   data_sources              = ["CLOUDWATCH", "PROMETHEUS", "XRAY"]
   notification_destinations = ["SNS"]
   stack_set_name            = local.name
-  grafana_version           = "9.4"
+  grafana_version           = "10.4"
 
   configuration = jsonencode({
     unifiedAlerting = {
@@ -76,6 +76,40 @@ module "managed_grafana" {
     admin = {
       key_name        = "admin"
       key_role        = "ADMIN"
+      seconds_to_live = 3600
+    }
+  }
+
+  # Workspace service accounts
+  workspace_service_accounts = {
+    viewer = {
+      sa_name      = "viewer"
+      grafana_role = "VIEWER"
+    }
+    editor = {
+      sa_name      = "editor"
+      grafana_role = "EDITOR"
+    }
+    admin = {
+      sa_name      = "admin"
+      grafana_role = "ADMIN"
+    }
+  }
+
+  workspace_sa_tokens = {
+    viewer = {
+      token_name      = "viewer"
+      sa_account      = "viewer"
+      seconds_to_live = 3600
+    }
+    editor = {
+      token_name      = "editor"
+      sa_account      = "editor"
+      seconds_to_live = 3600
+    }
+    admin = {
+      token_name      = "admin"
+      sa_account      = "admin"
       seconds_to_live = 3600
     }
   }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 data "aws_availability_zones" "available" {}
 
 locals {
-  region      = "us-east-1"
+  region      = "us-west-2"
   name        = "amg-ex-${replace(basename(path.cwd), "_", "-")}"
   description = "AWS Managed Grafana service for ${local.name}"
 
@@ -98,17 +98,17 @@ module "managed_grafana" {
 
   workspace_sa_tokens = {
     viewer = {
-      token_name      = "viewer"
+      token_name      = "viewer-example"
       sa_account      = "viewer"
       seconds_to_live = 3600
     }
     editor = {
-      token_name      = "editor"
+      token_name      = "editor-example"
       sa_account      = "editor"
       seconds_to_live = 3600
     }
     admin = {
-      token_name      = "admin"
+      token_name      = "admin-example"
       sa_account      = "admin"
       seconds_to_live = 3600
     }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -29,6 +29,17 @@ output "workspace_grafana_version" {
 output "workspace_api_keys" {
   description = "The workspace API keys created including their attributes"
   value       = module.managed_grafana.workspace_api_keys
+  sensitive   = true
+}
+
+################################################################################
+# Serivce accounts token
+################################################################################
+
+output "workspace_sa_tokens" {
+  description = "The workspace API keys created including their attributes"
+  value       = module.managed_grafana.workspace_sa_tokens
+  sensitive   = true
 }
 
 ################################################################################

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -33,12 +33,18 @@ output "workspace_api_keys" {
 }
 
 ################################################################################
-# Serivce accounts token
+# Workspace Service Account
 ################################################################################
 
-output "workspace_sa_tokens" {
-  description = "The workspace API keys created including their attributes"
-  value       = module.managed_grafana.workspace_sa_tokens
+output "workspace_service_accounts" {
+  description = "The workspace service accounts created including their attributes"
+  value       = module.managed_grafana.workspace_service_accounts
+  sensitive   = true
+}
+
+output "workspace_service_account_tokens" {
+  description = "The workspace service account tokens created including their attributes"
+  value       = module.managed_grafana.workspace_service_account_tokens
   sensitive   = true
 }
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.59"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -114,23 +114,19 @@ resource "aws_grafana_workspace_api_key" "this" {
 # Workspace Service Account
 ################################################################################
 
-locals {
-  create_service_account = var.create && var.create_service_account
-  create_sa_tokens       = var.create_sa_tokens && local.create_service_account
-}
-
 resource "aws_grafana_workspace_service_account" "this" {
-  for_each = { for k, v in var.workspace_service_accounts : k => v if local.create_service_account }
+  for_each = { for k, v in var.workspace_service_accounts : k => v if var.create }
 
-  name         = try(each.value.sa_name, each.key)
+  name         = try(each.value.name, each.key)
   grafana_role = each.value.grafana_role
   workspace_id = local.workspace_id
 }
 
 resource "aws_grafana_workspace_service_account_token" "this" {
-  for_each           = { for k, v in var.workspace_sa_tokens : k => v if local.create_sa_tokens }
-  name               = try(each.value.token_name, each.key)
-  service_account_id = aws_grafana_workspace_service_account.this[each.value.sa_account].service_account_id
+  for_each = { for k, v in var.workspace_service_account_tokens : k => v if var.create }
+
+  name               = try(each.value.name, each.key)
+  service_account_id = try(aws_grafana_workspace_service_account.this[each.value.service_account_key].service_account_id, each.value.service_account_id)
   seconds_to_live    = each.value.seconds_to_live
   workspace_id       = local.workspace_id
 }

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "aws_grafana_workspace_api_key" "this" {
 }
 
 ################################################################################
-# Workspace Service Account 
+# Workspace Service Account
 ################################################################################
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,7 @@ locals {
 }
 
 resource "aws_grafana_workspace_service_account" "this" {
-  for_each = { for k, v in var.workspace_sa_tokens : k => v if local.create_service_account }
+  for_each = { for k, v in var.workspace_service_accounts : k => v if local.create_service_account }
 
   name         = try(each.value.sa_name, each.key)
   grafana_role = each.value.grafana_role

--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,31 @@ resource "aws_grafana_workspace_api_key" "this" {
 }
 
 ################################################################################
+# Workspace Service Account 
+################################################################################
+
+locals {
+  create_service_account = var.create && var.create_service_account
+  create_sa_tokens       = var.create_sa_tokens && local.create_service_account
+}
+
+resource "aws_grafana_workspace_service_account" "this" {
+  for_each = { for k, v in var.workspace_sa_tokens : k => v if local.create_service_account }
+
+  name         = try(each.value.sa_name, each.key)
+  grafana_role = each.value.grafana_role
+  workspace_id = local.workspace_id
+}
+
+resource "aws_grafana_workspace_service_account_token" "this" {
+  for_each           = { for k, v in var.workspace_sa_tokens : k => v if local.create_sa_tokens }
+  name               = try(each.value.token_name, each.key)
+  service_account_id = aws_grafana_workspace_service_account.this[each.value.sa_account].service_account_id
+  seconds_to_live    = each.value.seconds_to_live
+  workspace_id       = local.workspace_id
+}
+
+################################################################################
 # Workspace IAM Role
 ################################################################################
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,12 +32,17 @@ output "workspace_api_keys" {
 }
 
 ################################################################################
-# Workspace serivce accounts token
+# Workspace Service Account
 ################################################################################
 
-output "workspace_sa_tokens" {
-  description = "The workspace API keys created including their attributes"
-  value       = { for k, v in aws_grafana_workspace_service_account_token.this : k => v.key }
+output "workspace_service_accounts" {
+  description = "The workspace service accounts created including their attributes"
+  value       = aws_grafana_workspace_service_account_token.this
+}
+
+output "workspace_service_account_tokens" {
+  description = "The workspace service account tokens created including their attributes"
+  value       = aws_grafana_workspace_service_account_token.this
 }
 
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,6 +32,15 @@ output "workspace_api_keys" {
 }
 
 ################################################################################
+# Workspace serivce accounts token
+################################################################################
+
+output "workspace_sa_tokens" {
+  description = "The workspace API keys created including their attributes"
+  value       = { for k, v in aws_grafana_workspace_service_account_token.this : k => v.key }
+}
+
+################################################################################
 # Workspace IAM Role
 ################################################################################
 

--- a/variables.tf
+++ b/variables.tf
@@ -197,6 +197,34 @@ variable "workspace_api_keys" {
 }
 
 ################################################################################
+# Workspace Service Account
+################################################################################
+
+variable "create_service_account" {
+  description = "Determines whether a service account will be created"
+  type        = bool
+  default     = true
+}
+
+variable "create_sa_tokens" {
+  description = "Determines whether a service account token will be created"
+  type        = bool
+  default     = true
+}
+
+variable "workspace_service_accounts" {
+  description = "Map of workspace service account definitions to create"
+  type        = any
+  default     = {}
+}
+
+variable "workspace_sa_tokens" {
+  description = "Map of workspace service account tokens to create"
+  type        = any
+  default     = {}
+}
+
+################################################################################
 # Workspace SAML Configuration
 ################################################################################
 

--- a/variables.tf
+++ b/variables.tf
@@ -200,25 +200,13 @@ variable "workspace_api_keys" {
 # Workspace Service Account
 ################################################################################
 
-variable "create_service_account" {
-  description = "Determines whether a service account will be created"
-  type        = bool
-  default     = true
-}
-
-variable "create_sa_tokens" {
-  description = "Determines whether a service account token will be created"
-  type        = bool
-  default     = true
-}
-
 variable "workspace_service_accounts" {
   description = "Map of workspace service account definitions to create"
   type        = any
   default     = {}
 }
 
-variable "workspace_sa_tokens" {
+variable "workspace_service_account_tokens" {
   description = "Map of workspace service account tokens to create"
   type        = any
   default     = {}

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.59"
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add the ability to use the aws_grafana_workspace_service_account and aws_grafana_workspace_service_account_token

## Motivation and Context
- Resolves #35 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
no, API keys are still available.
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
