### PR TITLE
feat: Support `aws_grafana_license_association.grafana_token`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.59 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.63 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.59 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.63 |
 
 ## Modules
 
@@ -131,6 +131,7 @@ No modules.
 | <a name="input_data_sources"></a> [data\_sources](#input\_data\_sources) | The data sources for the workspace. Valid values are `AMAZON_OPENSEARCH_SERVICE`, `ATHENA`, `CLOUDWATCH`, `PROMETHEUS`, `REDSHIFT`, `SITEWISE`, `TIMESTREAM`, `XRAY` | `list(string)` | `[]` | no |
 | <a name="input_description"></a> [description](#input\_description) | The workspace description | `string` | `null` | no |
 | <a name="input_enable_alerts"></a> [enable\_alerts](#input\_enable\_alerts) | Determines whether IAM permissions for alerting are enabled for the workspace IAM role | `bool` | `false` | no |
+| <a name="input_grafana_token"></a> [grafana\_token](#input\_grafana\_token) | A token from Grafana Labs that ties your AWS account with a Grafana Labs account | `string` | `null` | no |
 | <a name="input_grafana_version"></a> [grafana\_version](#input\_grafana\_version) | Specifies the version of Grafana to support in the new workspace. If not specified, the default version for the `aws_grafana_workspace` resource will be used. See `aws_grafana_workspace` documentation for available options. | `string` | `null` | no |
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | Existing IAM role ARN for the workspace. Required if `create_iam_role` is set to `false` | `string` | `null` | no |
 | <a name="input_iam_role_description"></a> [iam\_role\_description](#input\_iam\_role\_description) | The description of the workspace IAM role | `string` | `null` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,13 +24,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.59 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.63 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.59 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.63 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.59"
+      version = ">= 5.63"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -399,8 +399,9 @@ resource "aws_grafana_workspace_saml_configuration" "this" {
 resource "aws_grafana_license_association" "this" {
   count = var.create && var.associate_license ? 1 : 0
 
-  license_type = var.license_type
-  workspace_id = local.workspace_id
+  grafana_token = var.grafana_token
+  license_type  = var.license_type
+  workspace_id  = local.workspace_id
 }
 
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -310,6 +310,12 @@ variable "license_type" {
   default     = "ENTERPRISE"
 }
 
+variable "grafana_token" {
+  description = "A token from Grafana Labs that ties your AWS account with a Grafana Labs account"
+  type        = string
+  default     = null
+}
+
 ################################################################################
 # Role Association
 ################################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.59"
+      version = ">= 5.63"
     }
   }
 }


### PR DESCRIPTION
## Description
Support `grafana_token`.
Ran some terraform plans with this new argument but difficult for me to actually test. 

## Motivation and Context
Closes: https://github.com/terraform-aws-modules/terraform-aws-managed-service-grafana/issues/37
https://github.com/hashicorp/terraform-provider-aws/issues/38743
https://github.com/hashicorp/terraform-provider-aws/issues/38775

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
